### PR TITLE
added plugin path to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
+GOBIN := $(shell go env GOPATH)/bin
+
 all: protogen
 
 protogen:
-	protoc -I=./proto --go_out=./proto --go_opt=paths=source_relative --go-grpc_out=proto --go-grpc_opt=paths=source_relative ./proto/*.proto
+	protoc -I=./proto --go_out=./proto --go_opt=paths=source_relative --go-grpc_out=proto --go-grpc_opt=paths=source_relative --plugin=protoc-gen-go=$(GOBIN)/protoc-gen-go --plugin=protoc-gen-go-grpc=$(GOBIN)/protoc-gen-go-grpc ./proto/*.proto
 	python3 -m grpc_tools.protoc -I ./proto --python_out=./proto --grpc_python_out=./proto --mypy_out=./proto --mypy_grpc_out=./proto ./proto/*.proto 
 
 cloud: protogen


### PR DESCRIPTION
protoc-gen-go und protoc-gen-go-grpc sind eigentlich in meinen PATH variablen, trotzdem schmeisst das script mir einen error dass sie nicht gefunden werden. Hab schnell diesen fix implementiert, mit dem läuft es lokal bei mir.